### PR TITLE
Add MaterialPropertyBlock cache to avoid GC alloc

### DIFF
--- a/Assets/Kvant/Spray/Spray.cs
+++ b/Assets/Kvant/Spray/Spray.cs
@@ -275,6 +275,7 @@ namespace Kvant
         BulkMesh _bulkMesh;
         Material _kernelMaterial;
         Material _debugMaterial;
+        MaterialPropertyBlock _props;
         bool _needsReset = true;
 
         static float deltaTime {
@@ -468,7 +469,11 @@ namespace Kvant
             }
 
             // Make a material property block for the following drawcalls.
-            var props = new MaterialPropertyBlock();
+            if (_props == null)
+            {
+                _props = new MaterialPropertyBlock();
+            }
+            var props = _props;
             props.SetTexture("_PositionBuffer", _positionBuffer2);
             props.SetTexture("_RotationBuffer", _rotationBuffer2);
             props.SetFloat("_ScaleMin", _scale * (1 - _scaleRandomness));


### PR DESCRIPTION
Since there's no good reason to create MaterialPropertyBlock each frame, simply cache single instance.

Other possible implementations are:

(1) Implement cache as property
(2) Create MaterialPropertyBlock at ResetResources()

Reason of avoiding (1) is consistency.  It means that other parts of Kvant.Spray aren't implemented with C# property.
Reason of avoiding (2) is simplicity.